### PR TITLE
remove the compile warning in arduino ide

### DIFF
--- a/src/basicMPU6050.tpp
+++ b/src/basicMPU6050.tpp
@@ -40,7 +40,7 @@ void basicMPU6050<TEMPLATE_INPUTS>
   Wire.beginTransmission(MPU_ADDRESS);        
   Wire.write(reg);                                                   
   Wire.endTransmission();                                               
-  Wire.requestFrom(MPU_ADDRESS, 2, true);       
+  Wire.requestFrom(static_cast<uint8_t>(MPU_ADDRESS), static_cast<size_t>(2), true);       
 }
 
 template<TEMPLATE_TYPE>


### PR DESCRIPTION
C:\Users\xxx\AppData\Local\Arduino15\packages\arduino\hardware\megaavr\1.8.7\libraries\Wire\src/Wire.h:64:12: note: candidate 1: size_t TwoWire::requestFrom(int, int, int)
     size_t requestFrom(int, int, int);
            ^~~~~~~~~~~
C:\Users\xxx\AppData\Local\Arduino15\packages\arduino\hardware\megaavr\1.8.7\libraries\Wire\src/Wire.h:62:12: note: candidate 2: virtual size_t TwoWire::requestFrom(uint8_t, size_t, bool)
     size_t requestFrom(uint8_t, size_t, bool);
            ^~~~~~~~~~~